### PR TITLE
fix: revert milestone to tagName change

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,15 +51,15 @@ jobs:
        milestone: ${{ steps.gitversion.outputs.majorMinorPatch }}
        name: 'Release ${{ steps.gitversion.outputs.majorMinorPatch }}'
 
-    - name: Publish release with GitReleaseManager
+    - name: Publish release and tag with GitReleaseManager
       uses: gittools/actions/gitreleasemanager/publish@v0.10.2
       with:
        token: ${{ secrets.GITHUB_TOKEN }}
        owner: ${{ steps.repo.outputs._0 }}
        repository: ${{ steps.repo.outputs._1 }}
-       milestone: ${{ steps.gitversion.outputs.majorMinorPatch }}
+       tagName: ${{ steps.gitversion.outputs.majorMinorPatch }}
 
-    - name: Close release with GitReleaseManager
+    - name: Close milestone with GitReleaseManager
       uses: gittools/actions/gitreleasemanager/close@v0.10.2
       with:
        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This was based on GRM's output: 
![image](https://github.com/davidzwa/grm-flow-test/assets/6005355/b7151c8b-41f3-4810-8d6f-d87efd5e98e0)
